### PR TITLE
Update create_command.go

### DIFF
--- a/create_command.go
+++ b/create_command.go
@@ -100,6 +100,8 @@
 			Resources: []*string{resp.ImageID},
 			Tags: []*ec2.Tag{
 				&ec2.Tag{ Key: aws.String("ec2-snapper-instance-id"), Value: &c.InstanceId },
+				&*ec2.Tag{
+				&ec2.Tag{ Key: aws.String("Name"), Value: &c.Name },
 			},
 		})
 

--- a/create_command.go
+++ b/create_command.go
@@ -100,7 +100,6 @@
 			Resources: []*string{resp.ImageID},
 			Tags: []*ec2.Tag{
 				&ec2.Tag{ Key: aws.String("ec2-snapper-instance-id"), Value: &c.InstanceId },
-				&*ec2.Tag{
 				&ec2.Tag{ Key: aws.String("Name"), Value: &c.Name },
 			},
 		})


### PR DESCRIPTION
Add the ability to create a value for the default aws Name tag.
