### PR TITLE
Refactor code for testing; add some unit and integration tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,9 @@ I personally use it to backup my Wordpress blog which is running as a single EC2
 
 ## Prerequisites
 
-### 1. Indicate your AWS Region
-ec2-snapper needs to know which AWS region to operate on. You can tell it by exporting this environment variable:
+You will need to setup your AWS credentials so ec2-snapper can authenticate to AWS.
 
-```
-AWS_REGION=us-west-2
-```
-Common USA regions are:
-
-- North Virginia = `us-east-1`
-- North California = `us-west-1`
-- Oregon = `us-west-2`
-
-_*Tip: To export an environment variable on most linux distro's, edit the file `/etc/environment`.  You may need to reboot before this takes effect, or you can try the command `. /etc/environment` to apply the changes immediately.*_
-
-### 2. Setup Your AWS Credentials
-You will also need to authenticate to AWS.
-
-#### Option 1: Set Environment Variables
+### Option 1: Set Environment Variables
 One option is to authenticate by exporting the following environment variables:
 
 ```
@@ -54,10 +39,10 @@ AWS_ACCESS_KEY_ID=AKID1234567890
 AWS_SECRET_ACCESS_KEY=MY-SECRET-KEY
 ```
 
-#### Option 2: Use IAM Roles
+### Option 2: Use IAM Roles
 If you're running ec2-snapper on an Amazon EC2 instance, the preferred way to authenticate is by assigning an [IAM Role](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) to your EC2 instance.  Note that IAM roles can only be assigned when an EC2 instance is being launched, and not after the fact.
 
-#### Account Permissions
+### Account Permissions
 Whichever method you use to authenticate, the AWS account you use to authenticate will need the limited set of IAM permissions in this IAM policy:
 
 ```
@@ -107,9 +92,9 @@ For all options, run ```ec2-snapper create --help```.
 
 ```
 Example:
-ec2-snapper create --instance=i-c724be30 --name=MyEc2Instance --dry-run --no-reboot
+ec2-snapper create --region us-west-2 --instance=i-c724be30 --name=MyEc2Instance --dry-run --no-reboot
 ```
-You must specify the EC2 instance ID (e.g. `i-c724be30`) to be snapshotted, and give it a name such as "MyWebsite.com".  A current timestamp will automatically be appended to the name.  
+You must specify the AWS region (e.g. `us-west-2`) and the ID of an EC2 instance in that region (e.g. `i-c724be30`) to be snapshotted, and give it a name such as "MyWebsite.com".  A current timestamp will automatically be appended to the name.
 
 For example, `./ec2-snapper create --instance i-c724be30 --name "MyWebsite.com"` resulted in an AMI named "MyWebsite.com - 2015-06-08 at 08_26_51 (UTC)".
 
@@ -124,9 +109,9 @@ For all options, run ```ec2-snapper delete --help```.
 
 ```
 Example:
-ec2-snapper delete --instance=i-c724b30 --older-than=30d --dry-run
+ec2-snapper delete --region us-west-2 --instance=i-c724b30 --older-than=30d --dry-run
 ```
-You must specify the EC2 instance ID (e.g. `i-c724be30`) originally used to create the AMIs you wish to delete, even if that EC2 instance has since been stopped or terminated.  
+You must specify the AWS region (e.g. `us-west-2`) and the ID of an EC2 instance in that region (e.g. `i-c724be30`) originally used to create the AMIs you wish to delete, even if that EC2 instance has since been stopped or terminated.
 
 `--older-than` accepts time values like `30d`, `5h` or `15m` for 30 days, 5 hours, or 15 minutes, respectively.  For example, `--older-than=30d` tells ec2-snapper to delete any AMI for the given EC2 instance that is older than 30 days.
 
@@ -136,3 +121,26 @@ You must specify the EC2 instance ID (e.g. `i-c724be30`) originally used to crea
 
 ## Contributors
 This was my first golang program, so I'm sure the code can benefit from various optimizations.  Pull requests and bug reports are always welcome.
+
+## Tests
+This repo contains two types of tests:
+
+1. Unit tests: fast, isolated tests of individual functions. They use the name format `unit_xxx_test.go`.
+2. Integration tests: slower, end-to-end tests that create and delete real resources in an AWS account. **All the
+   resources should fit into the AWS free tier, but if you've used up all your credits, you may be charged!**
+   Integration tests use the name format `integration_xxx_test.go`.
+
+To run the tests, first, set your AWS credentials using the environment variables `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY`.
+
+To run all the tests:
+
+```bash
+./_ci/run-tests.sh
+```
+
+To run a specific test:
+
+```bash
+go test -run MY_TEST_NAME
+```

--- a/_ci/run-tests.sh
+++ b/_ci/run-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This script is meant to be run in a CI job to run the automated tests.
+
+set -e
+
+# Go's default test timeout is 10 minutes, after which it unceremoniously kills the entire test run, preventing any
+# cleanup from running. To prevent that, we set a higher timeout.
+readonly TEST_TIMEOUT="30m"
+
+# Our tests do very little that is CPU intensive and spend the vast majority of their time just waiting for AWS, so
+# run as many of them in parallel as we can. Circle CI boxes have 32 cores, so this is just 4 tests per core, which it
+# should easily be able to handle if we ever get to the point that we have 128 tests!
+readonly TEST_PARALLELISM="128"
+
+# SCRIPT_DIR contains the location of the script you're reading now
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/.."
+
+# Set the verbose flag so we get log output even if the tests pass
+go test -v -timeout "$TEST_TIMEOUT" -parallel "$TEST_PARALLELISM"

--- a/_ci/run-tests.sh
+++ b/_ci/run-tests.sh
@@ -16,5 +16,8 @@ readonly TEST_PARALLELISM="128"
 readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR/.."
 
+# Install test dependencies
+go test -i
+
 # Set the verbose flag so we get log output even if the tests pass
 go test -v -timeout "$TEST_TIMEOUT" -parallel "$TEST_PARALLELISM"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+machine:
+  environment:
+    IMPORT_PATH: "github.com/gruntwork-io/${CIRCLE_PROJECT_REPONAME}"
+    REPO: "$HOME/.go_workspace/src/${IMPORT_PATH}"
+    GOOS: linux
+
+dependencies:
+  override:
+    # Get our repo into the CircleCI GOPATH.
+    - |
+        mkdir -p ${REPO}
+        rmdir ${REPO}
+        ln -s "/home/ubuntu/${CIRCLE_PROJECT_REPONAME}" "${REPO}"
+
+test:
+  override:
+    - |
+        ${REPO}/_ci/run-tests.sh

--- a/create_command.go
+++ b/create_command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/cli"
-"errors"
+	"errors"
 )
 
 type CreateCommand struct {

--- a/create_command.go
+++ b/create_command.go
@@ -9,10 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mitchellh/cli"
+"errors"
 )
 
 type CreateCommand struct {
 	Ui 		cli.Ui
+	AwsRegion 	string
 	InstanceId 	string
 	Name 		string
 	DryRun		bool
@@ -20,6 +22,7 @@ type CreateCommand struct {
 }
 
 // descriptions for args
+var createDscrAwsRegion = "The AWS region to use (e.g. us-west-2)"
 var createDscrInstanceId = "The instance from which to create the AMI"
 var createDscrName = "The name of the AMI; the current timestamp will be automatically appended"
 var createDscrDryRun = "Execute a simulated run"
@@ -31,6 +34,7 @@ func (c *CreateCommand) Help() string {
 Create an AMI of the given EC2 instance.
 
 Available args are:
+--region      ` + createDscrAwsRegion + `
 --instance      ` + createDscrInstanceId + `
 --name          ` + createDscrName + `
 --dry-run       ` + createDscrDryRun + `
@@ -47,6 +51,7 @@ func (c *CreateCommand) Run(args []string) int {
 	cmdFlags := flag.NewFlagSet("create", flag.ExitOnError)
 	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
 
+	cmdFlags.StringVar(&c.AwsRegion, "region", "", createDscrAwsRegion)
 	cmdFlags.StringVar(&c.InstanceId, "instance", "", createDscrInstanceId)
 	cmdFlags.StringVar(&c.Name, "name", "", createDscrName)
 	cmdFlags.BoolVar(&c.DryRun, "dry-run", false, createDscrDryRun)
@@ -56,19 +61,32 @@ func (c *CreateCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Check for required command-line args
-	if c.InstanceId == "" {
-		c.Ui.Error("ERROR: The argument '--instance' is required.")
+	if _, err := create(*c); err != nil {
+		c.Ui.Error(err.Error())
 		return 1
+	}
+
+	return 0
+}
+
+func create(c CreateCommand) (string, error) {
+	snapshotId := ""
+
+	// Check for required command-line args
+	if c.AwsRegion == "" {
+		return snapshotId, errors.New("ERROR: The argument '--region' is required.")
+	}
+
+	if c.InstanceId == "" {
+		return snapshotId, errors.New("ERROR: The argument '--instance' is required.")
 	}
 
 	if c.Name == "" {
-		c.Ui.Error("ERROR: The argument '--name' is required.")
-		return 1
+		return snapshotId, errors.New("ERROR: The argument '--name' is required.")
 	}
 
 	// Create an EC2 service object; AWS region is picked up from the "AWS_REGION" env var.
-	session := session.New()
+	session := session.New(&aws.Config{Region: &c.AwsRegion})
 	svc := ec2.New(session)
 
 	// Generate a nicely formatted timestamp for right now
@@ -86,53 +104,54 @@ func (c *CreateCommand) Run(args []string) int {
 		DryRun: &c.DryRun,
 		NoReboot: &c.NoReboot })
 	if err != nil && strings.Contains(err.Error(), "NoCredentialProviders") {
-		c.Ui.Error("ERROR: No AWS credentials were found.  Either set the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or run this program on an EC2 instance that has an IAM Role with the appropriate permissions.")
-		return 1
+		return snapshotId, errors.New("ERROR: No AWS credentials were found.  Either set the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or run this program on an EC2 instance that has an IAM Role with the appropriate permissions.")
 	} else if err != nil {
-		panic(err)
+		return snapshotId, err
 	}
 
 	// Sleep here to give time for AMI to get found
 	time.Sleep(3000 * time.Millisecond)
 
 	// Assign tags to this AMI.  We'll use these when it comes time to delete the AMI
-	c.Ui.Output("==> Adding tags to AMI " + *resp.ImageId + "...")
+	snapshotId = *resp.ImageId
+	c.Ui.Output("==> Adding tags to AMI " + snapshotId + "...")
 
-	svc.CreateTags(&ec2.CreateTagsInput{
-		Resources: []*string{resp.ImageId},
+	_, tagsErr := svc.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{&snapshotId},
 		Tags: []*ec2.Tag{
 			&ec2.Tag{ Key: aws.String("ec2-snapper-instance-id"), Value: &c.InstanceId },
 			&ec2.Tag{ Key: aws.String("Name"), Value: &c.Name },
 		},
 	})
 
+	if tagsErr != nil {
+		return snapshotId, tagsErr
+	}
+
 	// Check the status of the AMI
 	respDscrImages, err := svc.DescribeImages(&ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
 			&ec2.Filter{
 				Name: aws.String("image-id"),
-				Values: []*string{resp.ImageId},
+				Values: []*string{&snapshotId},
 			},
 		},
 	})
 	if err != nil {
-		panic(err)
+		return snapshotId, err
 	}
 
 	// If no AMI at all was found, throw an error
 	if len(respDscrImages.Images) == 0 {
-		c.Ui.Error("ERROR: Could not find the AMI just created.")
-		return 1
+		return snapshotId, errors.New("ERROR: Could not find the AMI just created.")
 	}
 
 	// If the AMI's status is failed throw an error
 	if *respDscrImages.Images[0].State == "failed" {
-		c.Ui.Error("ERROR: AMI was created but entered a state of 'failed'. This is an AWS issue. Please re-run this command.  Note that you will need to manually de-register the AMI in the AWS console or via the API.")
-		return 1
+		return snapshotId, errors.New("ERROR: AMI was created but entered a state of 'failed'. This is an AWS issue. Please re-run this command.  Note that you will need to manually de-register the AMI in the AWS console or via the API.")
 	}
 
 	// Announce success
-	c.Ui.Info("==> Success! Created " + *resp.ImageId + " named \"" + name + "\"")
-	return 0
+	c.Ui.Info("==> Success! Created " + snapshotId + " named \"" + name + "\"")
+	return snapshotId, nil
 }
-

--- a/delete_command.go
+++ b/delete_command.go
@@ -12,10 +12,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"math"
+	"errors"
 )
 
 type DeleteCommand struct {
 	Ui 			cli.Ui
+	AwsRegion 		string
 	InstanceId 		string
 	OlderThan 		string
 	RequireAtLeast		int
@@ -23,6 +25,7 @@ type DeleteCommand struct {
 }
 
 // descriptions for args
+var deleteDscrAwsRegion = "The AWS region to use (e.g. us-west-2)"
 var deleteDscrInstanceId = "The EC2 instance from which the AMIs to be deleted were originally created."
 var deleteOlderThan = "Delete AMIs older than the specified time; accepts formats like '30d' or '4h'."
 var requireAtLeast = "Never delete AMIs such that fewer than this number of AMIs will remain. E.g. require at least 3 AMIs remain."
@@ -34,6 +37,7 @@ func (c *DeleteCommand) Help() string {
 Create an AMI of the given EC2 instance.
 
 Available args are:
+--region      		` + deleteDscrAwsRegion + `
 --instance      	` + deleteDscrInstanceId + `
 --older-than    	` + deleteOlderThan + `
 --require-at-least      ` + requireAtLeast + `
@@ -48,8 +52,11 @@ func (c *DeleteCommand) Run(args []string) int {
 
 	// Handle the command-line args
 	cmdFlags := flag.NewFlagSet("delete", flag.ExitOnError)
-	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
+	cmdFlags.Usage = func() {
+		c.Ui.Output(c.Help())
+	}
 
+	cmdFlags.StringVar(&c.AwsRegion, "region", "", deleteDscrAwsRegion)
 	cmdFlags.StringVar(&c.InstanceId, "instance", "", deleteDscrInstanceId)
 	cmdFlags.StringVar(&c.OlderThan, "older-than", "", deleteOlderThan)
 	cmdFlags.IntVar(&c.RequireAtLeast, "require-at-least", 0, requireAtLeast)
@@ -59,167 +66,72 @@ func (c *DeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Check for required command-line args
-	if c.InstanceId == "" {
-		c.Ui.Error("ERROR: The argument '--instance' is required.")
+	if err := deleteSnapshots(*c); err != nil {
+		c.Ui.Error(err.Error())
 		return 1
 	}
 
-	if c.OlderThan == "" {
-		c.Ui.Error("ERROR: The argument '--older-than' is required.")
-		return 1
+	return 0
+}
+
+func deleteSnapshots(c DeleteCommand) error {
+	if err := validateArgs(c); err != nil {
+		return err
 	}
 
-	if c.RequireAtLeast < 0 {
-		c.Ui.Error("ERROR: The argument '--require-at-least' must be a positive integer.")
-		return 1
-	}
-
-	// Warn the user that this is a dry run
 	if c.DryRun {
 		c.Ui.Warn("WARNING: This is a dry run, and no actions will be taken, despite what any output may say!")
 	}
 
 	// Create an EC2 service object; AWS region is picked up from the "AWS_REGION" env var.
-	session := session.New()
+	session := session.New(&aws.Config{Region: &c.AwsRegion})
 	svc := ec2.New(session)
 
-	// Get a list of the existing AMIs that were created for the given EC2 instance
-	resp, err := svc.DescribeImages(&ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{
-			&ec2.Filter{
-				Name: aws.String("tag:ec2-snapper-instance-id"),
-				Values: []*string{&c.InstanceId},
-			},
-		},
-	})
-	if err != nil && strings.Contains(err.Error(), "NoCredentialProviders") {
-		c.Ui.Error("ERROR: No AWS credentials were found.  Either set the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or run this program on an EC2 instance that has an IAM Role with the appropriate permissions.")
-		return 1
-	} else if err != nil {
-		panic(err)
+	images, err := findImages(c.InstanceId, svc)
+	if err != nil {
+		return err
 	}
-	if len(resp.Images) == 0 {
-		c.Ui.Error("No AMIs were found for EC2 instance \"" + c.InstanceId + "\"")
-		return 0
-	}
-
 	// Check that at least the --require-at-least number of AMIs exists
 	// - Note that even if this passes, we still want to avoid deleting so many AMIs that we go below the threshold
-	if len(resp.Images) <= c.RequireAtLeast {
-		c.Ui.Info("NO ACTION TAKEN. There are currently " + strconv.Itoa(len(resp.Images)) + " AMIs, and --require-at-least=" + strconv.Itoa(c.RequireAtLeast) + " so no further action can be taken.")
-		return 0
+	if len(images) <= c.RequireAtLeast {
+		c.Ui.Info("NO ACTION TAKEN. There are currently " + strconv.Itoa(len(images)) + " AMIs, and --require-at-least=" + strconv.Itoa(c.RequireAtLeast) + " so no further action can be taken.")
+		return nil
 	}
 
 	// Get the AWS Account ID of the current AWS account
 	// We need this to do a more efficient lookup on the snapshot volumes
-	awsAccountId := *resp.Images[0].OwnerId
+	awsAccountId := *images[0].OwnerId
 	c.Ui.Output("==> Identified current AWS Account Id as " + awsAccountId)
 
-	// Parse our date range
-	match, _ := regexp.MatchString("^[0-9]*(h|d|m)$", c.OlderThan)
-	if ! match {
-		c.Ui.Error("The --older-than value of \"" + c.OlderThan + "\" is not formatted properly.  Use formats like 30d or 24h")
-		return 0
+	hours, err := parseOlderThanToHours(c.OlderThan)
+	if err != nil {
+		return err
 	}
 
-	var minutes float64
-	var hours float64
-
-	// We were given a time like "12h"
-	if match, _ := regexp.MatchString("^[0-9]*(h)$", c.OlderThan); match {
-		hours, _ = strconv.ParseFloat(c.OlderThan[0:len(c.OlderThan)-1], 64)
-	}
-
-	// We were given a time like "15d"
-	if match, _ := regexp.MatchString("^[0-9]*(d)$", c.OlderThan); match {
-		hours, _ = strconv.ParseFloat(c.OlderThan[0:len(c.OlderThan)-1], 64)
-		hours *= 24
-	}
-
-	// We were given a time like "5m"
-	if match, _ := regexp.MatchString("^[0-9]*(m)$", c.OlderThan); match {
-		minutes, _ = strconv.ParseFloat(c.OlderThan[0:len(c.OlderThan)-1], 64)
-		hours = minutes/60
-	}
-
-	// Now filter the AMIs to only include those within our date range
-	var filteredAmis[]*ec2.Image
-	for i := 0; i < len(resp.Images); i++ {
-		now := time.Now()
-		creationDate, err := time.Parse(time.RFC3339Nano, *resp.Images[i].CreationDate)
-		if err != nil {
-			panic(err)
-		}
-
-		duration := now.Sub(creationDate)
-
-		if duration.Hours() > hours {
-			filteredAmis = append(filteredAmis, resp.Images[i])
-		}
+	filteredAmis, err := filterImagesByDateRange(images, hours)
+	if err != nil {
+		return err
 	}
 	c.Ui.Output("==> Found " + strconv.Itoa(len(filteredAmis)) + " total AMI(s) for deletion.")
 
 	if len(filteredAmis) == 0 {
-		c.Ui.Error("No AMIs to delete.")
-		return 0
+		c.Ui.Warn("No AMIs to delete.")
+		return nil
 	}
 
-	// Get a list of every single snapshot in our account
-	// (I wasn't able to find a better way to filter these, but suggestions welcome!)
-	respDscrSnapshots, err := svc.DescribeSnapshots(&ec2.DescribeSnapshotsInput{
-		OwnerIds: []*string{&awsAccountId},
-	})
+	allSnapshots, err := getAllSnapshots(awsAccountId, svc)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	c.Ui.Output("==> Found " + strconv.Itoa(len(respDscrSnapshots.Snapshots)) + " total snapshots in this account.")
+	c.Ui.Output("==> Found " + strconv.Itoa(len(allSnapshots)) + " total snapshots in this account.")
 
-	// Compute whether we should delete fewer AMIs to adhere to our --require-at-least requirement
-	var numTotalAmis = len(resp.Images)
-	var numFilteredAmis = len(filteredAmis)
-	var numAmisToRemainAfterDelete = numTotalAmis - numFilteredAmis
-	var numAmisToRemoveFromFiltered = math.Max(0.0, float64(c.RequireAtLeast - numAmisToRemainAfterDelete))
-
+	var numAmisToRemoveFromFiltered = computeNumAmisToRemove(images, filteredAmis, c.RequireAtLeast)
 	if numAmisToRemoveFromFiltered > 0.0 {
 		c.Ui.Output("==> Only deleting " + strconv.Itoa(len(filteredAmis) - int(numAmisToRemoveFromFiltered)) + " total AMIs to honor '--require-at-least=" + strconv.Itoa(c.RequireAtLeast) + "'.")
 	}
 
-	// Begin deleting AMIs...
-	for i := 0; i < len(filteredAmis) - int(numAmisToRemoveFromFiltered); i++ {
-		// Step 1: De-register the AMI
-		c.Ui.Output(*filteredAmis[i].ImageId + ": De-registering AMI named \"" + *filteredAmis[i].Name + "\"...")
-		_, err := svc.DeregisterImage(&ec2.DeregisterImageInput{
-			DryRun: &c.DryRun,
-			ImageId: filteredAmis[i].ImageId,
-		})
-		if err != nil {
-			if ! strings.Contains(err.Error(), "DryRunOperation") {
-				panic(err)
-			}
-		}
-
-		// Step 2: Delete the corresponding AMI snapshot
-		// Look at the "description" for each Snapshot to see if it contains our AMI id
-		var snapshotIds []string
-		for _, snapshot := range respDscrSnapshots.Snapshots {
-			if strings.Contains(*snapshot.Description, *filteredAmis[i].ImageId) {
-				snapshotIds = append(snapshotIds, *snapshot.SnapshotId)
-			}
-		}
-
-		// Delete all snapshots that were found
-		c.Ui.Output(*filteredAmis[i].ImageId + ": Found " + strconv.Itoa(len(snapshotIds)) + " snapshot(s) to delete")
-		for _, snapshotId := range snapshotIds {
-			c.Ui.Output(*filteredAmis[i].ImageId + ": Deleting snapshot " + snapshotId + "...")
-			svc.DeleteSnapshot(&ec2.DeleteSnapshotInput{
-				DryRun: &c.DryRun,
-				SnapshotId: &snapshotId,
-			})
-		}
-
-		c.Ui.Output(*filteredAmis[i].ImageId + ": Done!")
-		c.Ui.Output("")
+	if err := deleteAmis(filteredAmis, allSnapshots, numAmisToRemoveFromFiltered, svc, c.DryRun, c.Ui); err != nil {
+		return err
 	}
 
 	if c.DryRun {
@@ -227,6 +139,170 @@ func (c *DeleteCommand) Run(args []string) int {
 	} else {
 		c.Ui.Info("==> Success! Deleted " + strconv.Itoa(len(filteredAmis) - int(numAmisToRemoveFromFiltered)) + " AMI's and their corresponding snapshots.")
 	}
-	return 0
+	return nil
 }
 
+// Get a list of every single snapshot in our account
+// (I wasn't able to find a better way to filter these, but suggestions welcome!)
+func getAllSnapshots(awsAccountId string, svc *ec2.EC2) ([]*ec2.Snapshot, error) {
+	var noSnapshots []*ec2.Snapshot
+
+	respDscrSnapshots, err := svc.DescribeSnapshots(&ec2.DescribeSnapshotsInput{
+		OwnerIds: []*string{&awsAccountId},
+	})
+	if err != nil {
+		return noSnapshots, err
+	}
+
+	return respDscrSnapshots.Snapshots, nil
+}
+
+// Compute whether we should delete fewer AMIs to adhere to our --require-at-least requirement
+func computeNumAmisToRemove(images []*ec2.Image, filteredAmis []*ec2.Image, requireAtLeast int) float64 {
+	var numTotalAmis = len(images)
+	var numFilteredAmis = len(filteredAmis)
+	var numAmisToRemainAfterDelete = numTotalAmis - numFilteredAmis
+	return math.Max(0.0, float64(requireAtLeast - numAmisToRemainAfterDelete))
+}
+
+// Check for required command-line args
+func validateArgs(c DeleteCommand) error {
+	if c.AwsRegion == "" {
+		return errors.New("ERROR: The argument '--region' is required.")
+	}
+
+	if c.InstanceId == "" {
+		return errors.New("ERROR: The argument '--instance' is required.")
+	}
+
+	if c.OlderThan == "" {
+		return errors.New("ERROR: The argument '--older-than' is required.")
+	}
+
+	if c.RequireAtLeast < 0 {
+		return errors.New("ERROR: The argument '--require-at-least' must be a positive integer.")
+	}
+
+	return nil
+}
+
+// Now filter the AMIs to only include those within our date range
+func filterImagesByDateRange(images []*ec2.Image, olderThanHours float64) ([]*ec2.Image, error) {
+	var filteredAmis[]*ec2.Image
+
+	for i := 0; i < len(images); i++ {
+		now := time.Now()
+		creationDate, err := time.Parse(time.RFC3339Nano, *images[i].CreationDate)
+		if err != nil {
+			return filteredAmis, err
+		}
+
+		duration := now.Sub(creationDate)
+
+		if duration.Hours() > olderThanHours {
+			filteredAmis = append(filteredAmis, images[i])
+		}
+	}
+
+	return filteredAmis, nil
+}
+
+// Get a list of the existing AMIs that were created for the given EC2 instance
+func findImages(instanceId string, svc *ec2.EC2) ([]*ec2.Image, error) {
+	var noImages []*ec2.Image
+
+	// Get a list of the existing AMIs that were created for the given EC2 instance
+	resp, err := svc.DescribeImages(&ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("tag:ec2-snapper-instance-id"),
+				Values: []*string{&instanceId},
+			},
+		},
+	})
+	if err != nil && strings.Contains(err.Error(), "NoCredentialProviders") {
+		return noImages, errors.New("ERROR: No AWS credentials were found.  Either set the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or run this program on an EC2 instance that has an IAM Role with the appropriate permissions.")
+	} else if err != nil {
+		return noImages, err
+	}
+	if len(resp.Images) == 0 {
+		return noImages, errors.New("No AMIs were found for EC2 instance \"" + instanceId + "\"")
+	}
+
+	return resp.Images, nil
+}
+
+func deleteAmis(amis []*ec2.Image, snapshots []*ec2.Snapshot, numAmisToRemoveFromFiltered float64, svc *ec2.EC2, dryRun bool, ui cli.Ui) error {
+	for i := 0; i < len(amis) - int(numAmisToRemoveFromFiltered); i++ {
+		// Step 1: De-register the AMI
+		ui.Output(*amis[i].ImageId + ": De-registering AMI named \"" + *amis[i].Name + "\"...")
+		_, err := svc.DeregisterImage(&ec2.DeregisterImageInput{
+			DryRun: &dryRun,
+			ImageId: amis[i].ImageId,
+		})
+		if err != nil {
+			if ! strings.Contains(err.Error(), "DryRunOperation") {
+				return err
+			}
+		}
+
+		// Step 2: Delete the corresponding AMI snapshot
+		// Look at the "description" for each Snapshot to see if it contains our AMI id
+		var snapshotIds []string
+		for _, snapshot := range snapshots {
+			if strings.Contains(*snapshot.Description, *amis[i].ImageId) {
+				snapshotIds = append(snapshotIds, *snapshot.SnapshotId)
+			}
+		}
+
+		// Delete all snapshots that were found
+		ui.Output(*amis[i].ImageId + ": Found " + strconv.Itoa(len(snapshotIds)) + " snapshot(s) to delete")
+		for _, snapshotId := range snapshotIds {
+			ui.Output(*amis[i].ImageId + ": Deleting snapshot " + snapshotId + "...")
+			_, deleteErr := svc.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+				DryRun: &dryRun,
+				SnapshotId: &snapshotId,
+			})
+
+			if deleteErr != nil {
+				return deleteErr
+			}
+		}
+
+		ui.Output(*amis[i].ImageId + ": Done!")
+		ui.Output("")
+	}
+
+	return nil
+}
+
+// TODO: convert this to use Go's time.ParseDuration
+func parseOlderThanToHours(olderThan string) (float64, error) {
+	var minutes float64
+	var hours float64
+
+	// Parse our date range
+	match, _ := regexp.MatchString("^[0-9]*(h|d|m)$", olderThan)
+	if ! match {
+		return hours, errors.New("The --older-than value of \"" + olderThan + "\" is not formatted properly.  Use formats like 30d or 24h")
+	}
+
+	// We were given a time like "12h"
+	if match, _ := regexp.MatchString("^[0-9]*(h)$", olderThan); match {
+		hours, _ = strconv.ParseFloat(olderThan[0:len(olderThan)-1], 64)
+	}
+
+	// We were given a time like "15d"
+	if match, _ := regexp.MatchString("^[0-9]*(d)$", olderThan); match {
+		hours, _ = strconv.ParseFloat(olderThan[0:len(olderThan)-1], 64)
+		hours *= 24
+	}
+
+	// We were given a time like "5m"
+	if match, _ := regexp.MatchString("^[0-9]*(m)$", olderThan); match {
+		minutes, _ = strconv.ParseFloat(olderThan[0:len(olderThan)-1], 64)
+		hours = minutes/60
+	}
+
+	return hours, nil
+}

--- a/integration_create_delete_test.go
+++ b/integration_create_delete_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"testing"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/mitchellh/cli"
+	"os"
+	"fmt"
+	"log"
+	"encoding/base64"
+	"time"
+)
+
+const AWS_REGION_FOR_TESTING = "us-east-1"
+const AMAZON_LINUX_AMI_ID = "ami-08111162"
+
+const TEST_FILE_PATH = "/home/ec2-user/test-file"
+const USER_DATA_TEMPLATE =
+`#!/bin/bash
+set -e
+echo '%s' > "%s"
+`
+
+// An integration test that runs an EC2 instance, uses create_command to take a snapshot of it, and then delete_command
+// to delete that snapshot. Since testing these functions requires a lot of setup in an AWS account, it's faster and
+// easier to do a single integration test rather than a number of smaller unit tests that each do a lot of setup and
+// teardown.
+func TestCreateAndDelete(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New(os.Stdout, "TestCreateAndDelete ", log.LstdFlags)
+
+	session := session.New(&aws.Config{Region: aws.String(AWS_REGION_FOR_TESTING)})
+	svc := ec2.New(session)
+
+	instance, uniqueId := launchInstance(svc, logger, t)
+	defer terminateInstance(instance, svc, logger, t)
+	waitForInstanceToStart(instance, svc, logger, t)
+
+	ui := &cli.BasicUi{
+		Reader:      os.Stdin,
+		Writer:      os.Stdout,
+		ErrorWriter: os.Stderr,
+	}
+
+	snapshotId := takeSnapshot(instance, uniqueId, svc, ui, logger, t)
+	waitForSnapshotToBeAvailable(snapshotId, svc, logger, t)
+	verifySnapshotWorks(snapshotId, svc, logger, t)
+
+	deleteSnapshotForInstance(instance, ui, logger, t)
+	waitForSnapshotToBeDeleted(snapshotId, svc, logger, t)
+	verifySnapshotIsDeleted(snapshotId, svc, logger, t)
+}
+
+func launchInstance(svc *ec2.EC2, logger *log.Logger, t *testing.T) (*ec2.Instance, string) {
+	uniqueId := UniqueId()
+	userData := fmt.Sprint(USER_DATA_TEMPLATE, uniqueId, TEST_FILE_PATH)
+
+	logger.Printf("Launching EC2 instance in region %s. Its User Data will create a file %s with contents %s.", AWS_REGION_FOR_TESTING, TEST_FILE_PATH, uniqueId)
+
+	runResult, err := svc.RunInstances(&ec2.RunInstancesInput{
+		ImageId:      aws.String(AMAZON_LINUX_AMI_ID),
+		InstanceType: aws.String("t2.micro"),
+		MinCount:     aws.Int64(1),
+		MaxCount:     aws.Int64(1),
+		UserData:     aws.String(base64.StdEncoding.EncodeToString([]byte(userData))),
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(runResult.Instances) != 1 {
+		t.Fatalf("Expected to launch 1 instance but got %d", len(runResult.Instances))
+	}
+
+	instance := runResult.Instances[0]
+	logger.Printf("Launched instance %s", *instance.InstanceId)
+
+	tagInstance(instance, uniqueId, svc, logger, t)
+
+	return instance, uniqueId
+}
+
+func tagInstance(instance *ec2.Instance, uniqueId string, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+	logger.Printf("Adding tags to instance %s", *instance.InstanceId)
+
+	_ , err := svc.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{instance.InstanceId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(fmt.Sprintf("ec2-snapper-unit-test-%s", uniqueId)),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForInstanceToStart(instance *ec2.Instance, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+	logger.Printf("Waiting for instance %s to start...", *instance.InstanceId)
+	if err := svc.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{InstanceIds: []*string{instance.InstanceId}}); err != nil {
+		t.Fatal(err)
+	}
+	logger.Printf("Instance %s is now running", *instance.InstanceId)
+}
+
+func terminateInstance(instance *ec2.Instance, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+	logger.Printf("Terminating instance %s", *instance.InstanceId)
+	if _, err := svc.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: []*string{instance.InstanceId}}); err != nil {
+		t.Fatal("Failed to terminate instance %s", *instance.InstanceId)
+	}
+}
+
+func takeSnapshot(instance *ec2.Instance, uniqueId string, svc *ec2.EC2, ui cli.Ui, logger *log.Logger, t *testing.T) string {
+	backupName := fmt.Sprintf("ec2-snapper-unit-test-create-%s", uniqueId)
+	log.Printf("Creating a snapshot with name %s.", backupName)
+
+
+	cmd := CreateCommand{
+		Ui: ui,
+		AwsRegion: AWS_REGION_FOR_TESTING,
+		InstanceId: *instance.InstanceId,
+		Name: backupName,
+	}
+
+	snapshotId, err := create(cmd)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger.Printf("Created snasphot %s", snapshotId)
+	return snapshotId
+}
+
+func verifySnapshotWorks(snapshotId string, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+	logger.Printf("Verifying snapshot %s exists", snapshotId)
+
+	snapshots := findSnapshots(snapshotId, svc, logger, t)
+	if len(snapshots) != 1 {
+		t.Fatalf("Expected to find one snapshot with id %s but found %d", snapshotId, len(snapshots))
+	}
+
+	snapshot := snapshots[0]
+
+	if *snapshot.State == ec2.ImageStateAvailable {
+		logger.Printf("Found snapshot %s in expected state %s", snapshotId, *snapshot.State)
+	} else {
+		t.Fatalf("Expected image to be in state %s, but it was in state %s", ec2.ImageStateAvailable, *snapshot.State)
+	}
+
+	// TODO: fire up a new EC2 instance with the snapshot, SSH to it, and check the file we wrote is still there
+}
+
+func verifySnapshotIsDeleted(snapshotId string, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+	logger.Printf("Verifying snapshot %s is deleted", snapshotId)
+	snapshots := findSnapshots(snapshotId, svc, logger, t)
+	if len(snapshots) != 0 {
+		t.Fatalf("Expected to find zero snapshots with id %s but found %d", snapshotId, len(snapshots))
+	}
+}
+
+func findSnapshots(snapshotId string, svc *ec2.EC2, logger *log.Logger, t *testing.T) []*ec2.Image {
+	resp, err := svc.DescribeImages(&ec2.DescribeImagesInput{ImageIds: []*string{&snapshotId}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return resp.Images
+}
+
+func waitForSnapshotToBeAvailable(snapshotId string, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+	logger.Printf("Waiting for snapshot %s to become available", snapshotId)
+
+	if err := svc.WaitUntilImageAvailable(&ec2.DescribeImagesInput{ImageIds: []*string{&snapshotId}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForSnapshotToBeDeleted(snapshotId string, svc *ec2.EC2, logger *log.Logger, t *testing.T) {
+	logger.Printf("Waiting for snapshot %s to be deleted", snapshotId)
+
+	// We just do a simple sleep, as there is no built-in API call to wait for this.
+	time.Sleep(30 * time.Second)
+}
+
+func deleteSnapshotForInstance(instance *ec2.Instance, ui cli.Ui, logger *log.Logger, t *testing.T) {
+	logger.Printf("Deleting snapshot for instance %s", *instance.InstanceId)
+
+	deleteCmd := DeleteCommand{
+		Ui: ui,
+		AwsRegion: AWS_REGION_FOR_TESTING,
+		InstanceId: *instance.InstanceId,
+		OlderThan: "0h",
+		RequireAtLeast: 0,
+	}
+
+	if err := deleteSnapshots(deleteCmd); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -49,12 +49,6 @@ func main() {
 		},
 	}
 
-	// Confirm that AWS credentials are set as environment
-	if os.Getenv("AWS_REGION") == "" {
-		fmt.Println("ERROR: You must set the AWS_REGION environment variable to a value like \"us-west-2\" or \"us-east-1\"")
-		os.Exit(1)
-	}
-
 	exitStatus, err := c.Run()
 	if err != nil {
 		fmt.Println(os.Stderr, err.Error())

--- a/unit_parse_hours_test.go
+++ b/unit_parse_hours_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"testing"
+)
+
+const FLOATING_POINT_THRESHOLD = 0.000001
+
+func TestParseOlderThanToHoursInvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOlderThanToHours("not-a-valid-format")
+	if err == nil {
+		t.Fatal("Expected to get an error when parsing an invalid format, but got nil")
+	}
+}
+
+func TestParseOlderThanToHoursNegativeHours(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOlderThanToHours("-15h")
+	if err == nil {
+		t.Fatal("Expected to get an error when parsing a negative value, but got nil")
+	}
+}
+
+func TestParseOlderThanToHoursZeroHours(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("0h", 0, t)
+}
+
+func TestParseOlderThanToHoursOneHour(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("1h", 1, t)
+}
+
+func TestParseOlderThanToHoursTenHours(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("10h", 10, t)
+}
+
+func TestParseOlderThanToHoursNineHundredNinetyNineHours(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("999h", 999, t)
+}
+
+func TestParseOlderThanToHoursZeroMinutes(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("0m", 0, t)
+}
+
+func TestParseOlderThanToHoursOneMinute(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("1m", 0.01666666666667, t)
+}
+
+func TestParseOlderThanToHoursTenMinutes(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("10m", 0.16666666666667, t)
+}
+
+func TestParseOlderThanToHoursSixtyMinutes(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("60m", 1, t)
+}
+
+func TestParseOlderThanToHoursNineHundredNinetyNineMinutes(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("999m", 16.65, t)
+}
+
+func TestParseOlderThanToHoursZeroDays(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("0d", 0, t)
+}
+
+func TestParseOlderThanToHoursOneDay(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("1d", 24, t)
+}
+
+func TestParseOlderThanToHoursTenDays(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("10d", 240, t)
+}
+
+func TestParseOlderThanToHoursNineHundredNinetyNineDays(t *testing.T) {
+	t.Parallel()
+	testParseOlderThan("999d", 23976, t)
+}
+
+func testParseOlderThan(timeFormat string, expectedHours float64, t *testing.T) {
+	hours, err := parseOlderThanToHours(timeFormat)
+	if err != nil {
+		t.Fatalf("Unexpected error parsing a valid time format '%s': %s", timeFormat, err.Error())
+	}
+
+	diff := expectedHours - hours
+	if diff > FLOATING_POINT_THRESHOLD {
+		t.Fatalf("Expected %9f but got %9f. The difference %9f is greater than the floating point threshold %9f.", expectedHours, hours, diff, FLOATING_POINT_THRESHOLD)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+"bytes"
+"math/rand"
+	"time"
+)
+
+const BASE_62_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const UNIQUE_ID_LENGTH = 6 // Should be good for 62^6 = 56+ billion combinations
+
+// Returns a unique (ish) id we can attach to EC2 resources so they don't conflict with each other when tests run in
+// parallel Uses base 62 to generate a 6 character string that's unlikely to collide with the handful of tests we run in
+// parallel. Based on code here: http://stackoverflow.com/a/9543797/483528
+func UniqueId() string {
+	var out bytes.Buffer
+
+	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < UNIQUE_ID_LENGTH; i++ {
+		out.WriteByte(BASE_62_CHARS[rand.Intn(len(BASE_62_CHARS))])
+	}
+
+	return out.String()
+
+}


### PR DESCRIPTION
This PR does the following:
1. Refactor the code from two huge functions, one in `create_command` and one in `delete_command` into smaller functions that are more readable and more testable.
2. Add a basic end-to-end integration test that creates an EC2 instance, uses `create_command` to take a snapshot of it, and then uses `delete_command` to delete that snapshot. 
3. Add basic unit tests for the date parsing. However, this should be refactored to use `time.ParseDuration` in the future.
4. Adds a `circle.yml` file to run these tests in CI. @josh-padnick, could you enable a Circle CI build for this repo and add AWS credentials as environment variables? I don’t have access to it, so I can’t do it myself. 
5. Control aws region through a command line param rather than environment variables. This makes testing easier. It also allows you to run the `--help` command without getting an error about a missing environment variable.

There are a lot more unit and integration tests that should be added, especially for the deletion pieces, but I’m trying to strike a balance between making this code pristine via testing vs using this code in the real world (with clients). Hopefully, this lays down a decent base for tests, and we can add on more on top of it.
