### PR TITLE
Tag EBS volumes in addition to the AMI

### DIFF
--- a/integration_create_delete_test.go
+++ b/integration_create_delete_test.go
@@ -186,6 +186,11 @@ func launchInstance(svc *ec2.EC2, logger *log.Logger, t *testing.T) (*ec2.Instan
 	instance := runResult.Instances[0]
 	logger.Printf("Launched instance %s", *instance.InstanceId)
 
+	err = svc.WaitUntilInstanceExists(&ec2.DescribeInstancesInput{InstanceIds: []*string{instance.InstanceId}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tagInstance(instance, instanceName, svc, logger, t)
 
 	return instance, instanceName


### PR DESCRIPTION
This PR updates ec2-snapper so that it not only tags the AMIs it creates, but also the EBS volume snapshots that are created as part of the AMI process. This way, a client can restore either an entire EC2 instance from the AMI (easily finding the AMI using its tags), or just a specific EBS volume from its snapshot (easily finding the right snapshot using these newly added tags).
