### PR TITLE
Delete command should not error out if there are no existing snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.2 (September 14, 2016)
+
+* BUG: The ec2-snapper `delete` command now gracefully exits if no snapshots exist for the given instance rather than
+  exiting with an error.
+
 # 0.5.1 (September 11, 2016)
 
 * ENHANCEMENT: ec2-snapper now also tags the EBS volume snapshots it creates as part of the process of creating an AMI.

--- a/delete_command.go
+++ b/delete_command.go
@@ -103,6 +103,12 @@ func deleteSnapshots(c DeleteCommand) error {
 	if err != nil {
 		return err
 	}
+
+	if len(images) == 0 {
+		c.Ui.Info("NO ACTION TAKEN. There are no existing snapshots of instance " + c.InstanceId + " to delete.")
+		return nil
+	}
+
 	// Check that at least the --require-at-least number of AMIs exists
 	// - Note that even if this passes, we still want to avoid deleting so many AMIs that we go below the threshold
 	if len(images) <= c.RequireAtLeast {
@@ -236,9 +242,6 @@ func findImages(instanceId string, svc *ec2.EC2) ([]*ec2.Image, error) {
 		return noImages, errors.New("ERROR: No AWS credentials were found.  Either set the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or run this program on an EC2 instance that has an IAM Role with the appropriate permissions.")
 	} else if err != nil {
 		return noImages, err
-	}
-	if len(resp.Images) == 0 {
-		return noImages, errors.New("No AMIs were found for EC2 instance \"" + instanceId + "\"")
 	}
 
 	return resp.Images, nil

--- a/delete_command.go
+++ b/delete_command.go
@@ -97,6 +97,14 @@ func deleteSnapshots(c DeleteCommand) error {
 			return err
 		}
 		c.InstanceId = instanceId
+	} else {
+		result, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String(c.InstanceId)}})
+		if err != nil {
+			return err
+		}
+		if len(result.Reservations) == 0 || len(result.Reservations[0].Instances) == 0 {
+			return fmt.Errorf("Could not find an instance with id %s", c.InstanceId)
+		}
 	}
 
 	images, err := findImages(c.InstanceId, svc)

--- a/integration_create_delete_test.go
+++ b/integration_create_delete_test.go
@@ -100,7 +100,6 @@ func TestDeleteHandlesNoSnapshots(t *testing.T) {
 	defer terminateInstance(instance, svc, logger, t)
 	waitForInstanceToStart(instance, svc, logger, t)
 
-	// Set atLeast to 1 to ensure the snapshot, which is the only one that exists, does not get deleted
 	deleteSnapshotForInstance(instanceName, "0h", 0, ui, logger, t)
 }
 

--- a/integration_create_delete_test.go
+++ b/integration_create_delete_test.go
@@ -87,6 +87,23 @@ func TestDeleteRespectsAtLeast(t *testing.T) {
 	verifySnapshotWorks(snapshotId, svc, logger, t)
 }
 
+// An integration test that runs an EC2 instance, does not take any snapshots of it, and then calls the delete_command
+// to ensure that it exits gracefully even if no snapshots exist.
+func TestDeleteHandlesNoSnapshots(t *testing.T) {
+	t.Parallel()
+
+	logger, ui := createLoggerAndUi("TestDeleteHandlesNoSnapshots")
+	session := session.New(&aws.Config{Region: aws.String(AWS_REGION_FOR_TESTING)})
+	svc := ec2.New(session)
+
+	instance, instanceName := launchInstance(svc, logger, t)
+	defer terminateInstance(instance, svc, logger, t)
+	waitForInstanceToStart(instance, svc, logger, t)
+
+	// Set atLeast to 1 to ensure the snapshot, which is the only one that exists, does not get deleted
+	deleteSnapshotForInstance(instanceName, "0h", 0, ui, logger, t)
+}
+
 func TestCreateWithInvalidInstanceName(t *testing.T) {
 	t.Parallel()
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	}
 
 	// CLI stuff
-	c := cli.NewCLI("ec2-snapper", "0.5.1")
+	c := cli.NewCLI("ec2-snapper", "0.5.2")
 	c.Args = os.Args[1:]
 
 	c.Commands = map[string]cli.CommandFactory{


### PR DESCRIPTION
I had a case where I just created a new EC2 Instance and configured ec2-snapper to run on a periodic basis to backup that instance and to clean up old backups. However, when I ran the `delete` command the first time, having not created any backups before that, I got an error. I’ve updated the code to have the `delete` command exit gracefully if there are no backups to clean up.
